### PR TITLE
fix installation errors of gradle and maven  in setup

### DIFF
--- a/scripts/setup_gradle.py
+++ b/scripts/setup_gradle.py
@@ -8,6 +8,7 @@ CWE_BENCH_JAVA_ROOT_DIR = os.path.abspath(os.path.join(__file__, "..", ".."))
 JAVA_ENV_DIR = os.path.join(CWE_BENCH_JAVA_ROOT_DIR, "java-env")
 
 GRADLE_VERSIONS = json.load(open(f"{CWE_BENCH_JAVA_ROOT_DIR}/scripts/gradle_version.json"))
+JDK_VERSIONS = json.load(open(f"{CWE_BENCH_JAVA_ROOT_DIR}/scripts/jdk_version.json"))
 
 def download_gradle(version, info):
   print(f">> [CWE-Bench-Java/setup_gradle] Fetching Gradle {version}...")
@@ -23,10 +24,18 @@ def download_gradle(version, info):
     subprocess.run(["rm", info["zip_file"]], cwd=JAVA_ENV_DIR)
 
   print(f">> [CWE-Bench-Java/setup_gradle] Testing Downloaded Binary...")
+  
+  # Use JDK 8 as default for testing Gradle
+  default_jdk = "8u202"
+  java_home = f"{JAVA_ENV_DIR}/{JDK_VERSIONS[default_jdk]['dir']}"
+  
   output = subprocess.run(
     ["gradle", "--help"],
     cwd=JAVA_ENV_DIR,
-    env={"PATH": f"{os.environ['PATH']}:{JAVA_ENV_DIR}/{info['dir']}/bin"},
+    env={
+      "PATH": f"{os.environ['PATH']}:{JAVA_ENV_DIR}/{info['dir']}/bin",
+      "JAVA_HOME": java_home
+    },
     capture_output=True)
 
   if output.returncode == 0:

--- a/scripts/setup_mvn.py
+++ b/scripts/setup_mvn.py
@@ -8,6 +8,7 @@ CWE_BENCH_JAVA_ROOT_DIR = os.path.abspath(os.path.join(__file__, "..", ".."))
 JAVA_ENV_DIR = os.path.join(CWE_BENCH_JAVA_ROOT_DIR, "java-env")
 
 MVN_VERSIONS = json.load(open(f"{CWE_BENCH_JAVA_ROOT_DIR}/scripts/mvn_version.json"))
+JDK_VERSIONS = json.load(open(f"{CWE_BENCH_JAVA_ROOT_DIR}/scripts/jdk_version.json"))
 
 def download_mvn(version, info):
   print(f">> [CWE-Bench-Java/setup_mvn] Fetching Apache Maven {version}...")
@@ -23,10 +24,18 @@ def download_mvn(version, info):
     subprocess.run(["rm", info["zip_file"]], cwd=JAVA_ENV_DIR)
 
   print(f">> [CWE-Bench-Java/setup_mvn] Testing Downloaded Binary...")
+  
+  # Use JDK 8 as default for testing Maven
+  default_jdk = "8u202"
+  java_home = f"{JAVA_ENV_DIR}/{JDK_VERSIONS[default_jdk]['dir']}"
+  
   output = subprocess.run(
     ["mvn", "--help"],
     cwd=JAVA_ENV_DIR,
-    env={"PATH": f"{os.environ['PATH']}:{JAVA_ENV_DIR}/{info['dir']}/bin"},
+    env={
+      "PATH": f"{os.environ['PATH']}:{JAVA_ENV_DIR}/{info['dir']}/bin",
+      "JAVA_HOME": java_home
+    },
     capture_output=True)
 
   if output.returncode == 0:


### PR DESCRIPTION
Issues related to 

====== Setting up JDK ======
>> [CWE-Bench-Java/setup_jdk] Setting up JDK 17...
>> [CWE-Bench-Java/setup_jdk] JDK version 17 found; skipping
>> [CWE-Bench-Java/setup_jdk] Setting up JDK 7u80...
>> [CWE-Bench-Java/setup_jdk] JDK version 7u80 found; skipping
>> [CWE-Bench-Java/setup_jdk] Setting up JDK 8u202...
>> [CWE-Bench-Java/setup_jdk] JDK version 8u202 found; skipping
====== Setting up Maven ======
>> [CWE-Bench-Java/setup_mvn] Fetching Apache Maven 3.2.1...
>> [CWE-Bench-Java/setup_mvn] Maven version 3.2.1 found; skipping
>> [CWE-Bench-Java/setup_mvn] Testing Downloaded Binary...
>> [CWE-Bench-Java/setup_mvn] Maven version 3.2.1 installation failed:
Error: JAVA_HOME is not defined correctly.
  We cannot execute 

>> [CWE-Bench-Java/setup_mvn] Fetching Apache Maven 3.5.0...
>> [CWE-Bench-Java/setup_mvn] Maven version 3.5.0 found; skipping
>> [CWE-Bench-Java/setup_mvn] Testing Downloaded Binary...
>> [CWE-Bench-Java/setup_mvn] Maven version 3.5.0 installation failed:
The JAVA_HOME environment variable is not defined correctly
This environment variable is needed to run this program
NB: JAVA_HOME should point to a JDK not a JRE

>> [CWE-Bench-Java/setup_mvn] Fetching Apache Maven 3.9.8...
>> [CWE-Bench-Java/setup_mvn] Maven version 3.9.8 found; skipping
>> [CWE-Bench-Java/setup_mvn] Testing Downloaded Binary...
>> [CWE-Bench-Java/setup_mvn] Maven version 3.9.8 installation failed:
The JAVA_HOME environment variable is not defined correctly,
this environment variable is needed to run this program.

====== Setting up Gradle ======
>> [CWE-Bench-Java/setup_gradle] Fetching Gradle 8.9...
>> [CWE-Bench-Java/setup_gradle] Gradle version 8.9 found; skipping
>> [CWE-Bench-Java/setup_gradle] Testing Downloaded Binary...
>> [CWE-Bench-Java/setup_gradle] Gradle version 8.9 installation failed:

ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.


>> [CWE-Bench-Java/setup_gradle] Fetching Gradle 7.6.4...
>> [CWE-Bench-Java/setup_gradle] Gradle version 7.6.4 found; skipping
>> [CWE-Bench-Java/setup_gradle] Testing Downloaded Binary...
>> [CWE-Bench-Java/setup_gradle] Gradle version 7.6.4 installation failed:

ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.


>> [CWE-Bench-Java/setup_gradle] Fetching Gradle 6.8.2...
>> [CWE-Bench-Java/setup_gradle] Gradle version 6.8.2 found; skipping
>> [CWE-Bench-Java/setup_gradle] Testing Downloaded Binary...
>> [CWE-Bench-Java/setup_gradle] Gradle version 6.8.2 installation failed: